### PR TITLE
Fix file paths on Windows, find "tasks" and "data" relative to .py files

### DIFF
--- a/python/hpatches_eval.py
+++ b/python/hpatches_eval.py
@@ -4,16 +4,18 @@ Usage:
   hpatches_eval.py (-h | --help)
   hpatches_eval.py --version
   hpatches_eval.py --descr-name=<> --task=<>... [--descr-dir=<>] [--split=<>] [--dist=<>] [--delimiter=<>] [--pcapl=<>]
+
 Options:
-  -h --help        Show this screen.
-  --version        Show version.
-  --descr-name=<>  Descriptor name, e.g. sift
-  --descr-dir=<>   Descriptor results root folder  [default: {root}/data/descriptors]
-  --task=<>        Task name. Valid tasks are {verification,matching,retrieval}.
-  --split=<>       Split name. Valid are {a,b,c,full,illum,view} [default: a].
-  --dist=<>        Distance name. Valid are {L1,L2} [default: L2]
-  --delimiter=<>   Delimiter used in the csv files [default: ,]
-  --pcapl=<>       Compute results for pca-power law descr [default: no]
+  -h --help         Show this screen.
+  --version         Show version.
+  --descr-name=<>   Descriptor name, e.g. sift
+  --descr-dir=<>    Descriptor results root folder. [default: {root}/data/descriptors]
+  --results-dir=<>  Results root folder. [default: results]
+  --task=<>         Task name. Valid tasks are {verification,matching,retrieval}.
+  --split=<>        Split name. Valid are {a,b,c,full,illum,view}. [default: a]
+  --dist=<>         Distance name. Valid are {L1,L2}. [default: L2]
+  --delimiter=<>    Delimiter used in the csv files. [default: ,]
+  --pcapl=<>        Compute results for pca-power law descr. [default: no]
 
 For more visit: https://github.com/hpatches/
 """
@@ -38,8 +40,9 @@ if __name__ == '__main__':
        print("%r does not exist." % (path))
        exit(0)
 
-    if not os.path.exists('results'):
-        os.makedirs('results')
+    results_dir = opts['--results-dir']
+    if not os.path.exists(results_dir):
+        os.makedirs(results_dir)
 
     descr_name = opts['--descr-name']
     print('\n>> Running HPatch evaluation for %s' % blue(descr_name))
@@ -52,7 +55,7 @@ if __name__ == '__main__':
     splt = splits[opts['--split']]
 
     for t in opts['--task']:
-        res_path = os.path.join("results", descr_name+"_"+t+"_"+splt['name']+".p")
+        res_path = os.path.join(results_dir, descr_name+"_"+t+"_"+splt['name']+".p")
         if os.path.exists(res_path):
             print("Results for the %s, %s task, split %s, already cached!" %\
                   (descr_name,t,splt['name']))
@@ -65,7 +68,7 @@ if __name__ == '__main__':
         print('>> Running evaluation for %s normalisation' % blue("pca/power-law"))
         compute_pcapl(descr,splt)
         for t in opts['--task']:
-            res_path = os.path.join("results", descr_name+"_pcapl_"+t+"_"+splt['name']+".p")
+            res_path = os.path.join(results_dir, descr_name+"_pcapl_"+t+"_"+splt['name']+".p")
             if os.path.exists(res_path):
                 print("Results for the %s, %s task, split %s,PCA/PL already cached!" %\
                       (descr_name,t,splt['name']))

--- a/python/hpatches_eval.py
+++ b/python/hpatches_eval.py
@@ -3,7 +3,7 @@
 Usage:
   hpatches_eval.py (-h | --help)
   hpatches_eval.py --version
-  hpatches_eval.py --descr-name=<> --task=<>... [--descr-dir=<>] [--split=<>] [--dist=<>] [--delimiter=<>] [--pcapl=<>]
+  hpatches_eval.py --descr-name=<> --task=<>... [--descr-dir=<>] [--results-dir=<>] [--split=<>] [--dist=<>] [--delimiter=<>] [--pcapl=<>]
 
 Options:
   -h --help         Show this screen.

--- a/python/hpatches_eval.py
+++ b/python/hpatches_eval.py
@@ -8,7 +8,7 @@ Options:
   -h --help        Show this screen.
   --version        Show version.
   --descr-name=<>  Descriptor name, e.g. sift
-  --descr-dir=<>   Descriptor results root folder  [default: ../data/descriptors]
+  --descr-dir=<>   Descriptor results root folder  [default: {root}/data/descriptors]
   --task=<>        Task name. Valid tasks are {verification,matching,retrieval}.
   --split=<>       Split name. Valid are {a,b,c,full,illum,view} [default: a].
   --dist=<>        Distance name. Valid are {L1,L2} [default: L2]
@@ -27,43 +27,48 @@ import dill
 
 if __name__ == '__main__':
     opts = docopt(__doc__, version='HPatches 1.0')
-    path = os.path.join(opts['--descr-dir'],opts['--descr-name'])
+    descr_dir = opts['--descr-dir'].format(
+        root=os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."))
+    )
+    path = os.path.join(descr_dir, opts['--descr-name'])
 
     try:
         assert os.path.exists(path)
     except:
        print("%r does not exist." % (path))
        exit(0)
-    
+
     if not os.path.exists('results'):
         os.makedirs('results')
 
     descr_name = opts['--descr-name']
     print('\n>> Running HPatch evaluation for %s' % blue(descr_name))
-        
+
     descr = load_descrs(path,dist=opts['--dist'],sep=opts['--delimiter'])
 
-    with open('../tasks/splits/splits.json') as f:    
+    with open(os.path.join(tskdir, "splits", "splits.json")) as f:
         splits = json.load(f)
 
     splt = splits[opts['--split']]
-    
+
     for t in opts['--task']:
-        if os.path.exists("results/"+descr_name+"_"+t+"_"+splt['name']+".p"):
+        res_path = os.path.join("results", descr_name+"_"+t+"_"+splt['name']+".p")
+        if os.path.exists(res_path):
             print("Results for the %s, %s task, split %s, already cached!" %\
                   (descr_name,t,splt['name']))
         else:
             res = methods[t](descr,splt)
-            dill.dump( res, open( "results/"+descr_name+"_"+t+"_"+splt['name']+".p", "wb"))
+            dill.dump(res, open(res_path, "wb"))
 
     # do the PCA/power-law evaluation if wanted
     if opts['--pcapl']!='no':
         print('>> Running evaluation for %s normalisation' % blue("pca/power-law"))
         compute_pcapl(descr,splt)
         for t in opts['--task']:
-            if os.path.exists("results/"+descr_name+"_pcapl_"+t+"_"+splt['name']+".p"):
+            res_path = os.path.join("results", descr_name+"_pcapl_"+t+"_"+splt['name']+".p")
+            if os.path.exists(res_path):
                 print("Results for the %s, %s task, split %s,PCA/PL already cached!" %\
                       (descr_name,t,splt['name']))
             else:
                 res = methods[t](descr,splt)
-                dill.dump( res, open( "results/"+descr_name+"_pcapl_"+t+"_"+splt['name']+".p", "wb"))
+                dill.dump(res, open(res_path, "wb"))

--- a/python/hpatches_results.py
+++ b/python/hpatches_results.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     opts = docopt(__doc__, version='HPatches 1.0')
     descrs = opts['--descr-name']
 
-    with open('../tasks/splits/splits.json') as f:    
+    with open(os.path.join(tskdir, "splits", "splits.json")) as f:    
         splits = json.load(f)
     splt = splits[opts['--split']]
 
@@ -36,4 +36,4 @@ if __name__ == '__main__':
             if opts['--pcapl']!='no':
                 results_methods[t](desc+'_pcapl',splt)
             print
-        print 
+        print

--- a/python/hpatches_results.py
+++ b/python/hpatches_results.py
@@ -3,15 +3,16 @@
 Usage:
   hpatches_results.py (-h | --help)
   hpatches_results.py --version
-  hpatches_results.py --descr-name=<>... --results-dir=<> --task=<>... [--split=<>] [--pcapl=<>]
+  hpatches_results.py --descr-name=<>... --task=<>... [--results-dir=<>] [--split=<>] [--pcapl=<>]
+
 Options:
   -h --help         Show this screen.
   --version         Show version.
-  --descr-name=<>   Descriptor name e.g. --descr=sift
-  --results-dir=<>  Results root folder, e.g. --results-dir=./results
+  --descr-name=<>   Descriptor name e.g. --descr=sift.
+  --results-dir=<>  Results root folder. [default: results]
   --task=<>         Task name. Valid tasks are {verification,matching,retrieval}.
-  --split=<>        Split name. Valid are {a,b,c,full,illum,view} [default: a].
-  --pcapl=<>        Show results for pca-power law descr [default: no]
+  --split=<>        Split name. Valid are {a,b,c,full,illum,view}. [default: a]
+  --pcapl=<>        Show results for pca-power law descr. [default: no]
 
 For more visit: https://github.com/hpatches/
 """
@@ -26,7 +27,7 @@ if __name__ == '__main__':
     opts = docopt(__doc__, version='HPatches 1.0')
     descrs = opts['--descr-name']
 
-    with open(os.path.join(tskdir, "splits", "splits.json")) as f:    
+    with open(os.path.join(tskdir, "splits", "splits.json")) as f:
         splits = json.load(f)
     splt = splits[opts['--split']]
 

--- a/python/hpatches_results.py
+++ b/python/hpatches_results.py
@@ -15,6 +15,7 @@ Options:
 
 For more visit: https://github.com/hpatches/
 """
+from utils.tasks import tskdir
 from utils.results import *
 import os.path
 import time

--- a/python/hpatches_vis.py
+++ b/python/hpatches_vis.py
@@ -36,7 +36,7 @@ tp = tps
 ids = range(1,55)
 
 # load a sample sequence
-seq = hpatch_sequence(os.path.join(datadir, "hpatches-release", "v_calder")
+seq = hpatch_sequence(os.path.join(datadir, "hpatches-release", "v_calder"))
 vis = vis_patches(seq,tp,ids)
 
 # show

--- a/python/hpatches_vis.py
+++ b/python/hpatches_vis.py
@@ -1,10 +1,11 @@
 from utils.hpatch import *
-import cv2 
+import cv2
+import os.path
 
 
-# all types of patches 
-tps = ['ref','e1','e3','e5','h1','h3','h5',\
-       't1','t3','t5']
+# all types of patches
+tps = ['ref','e1','e3','e5','h1','h3','h5','t1','t3','t5']
+datadir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "data"))
 
 def vis_patches(seq,tp,ids):
     """Visualises a set of types and indices for a sequence"""
@@ -14,7 +15,7 @@ def vis_patches(seq,tp,ids):
     vis_tmp = np.empty((0,55))
     for t in tp:
         tp_patch = 255*np.ones((65,55))
-        cv2.putText(tp_patch,t,(5,25),cv2.FONT_HERSHEY_DUPLEX , 1,0,1)                       
+        cv2.putText(tp_patch,t,(5,25),cv2.FONT_HERSHEY_DUPLEX , 1,0,1)
         vis_tmp = np.vstack((vis_tmp,tp_patch))
     vis = np.hstack((vis,vis_tmp))
     # add the actual patches
@@ -35,10 +36,10 @@ tp = tps
 ids = range(1,55)
 
 # load a sample sequence
-seq = hpatch_sequence('../data/hpatches-release/v_calder/')
+seq = hpatch_sequence(os.path.join(datadir, "hpatches-release", "v_calder")
 vis = vis_patches(seq,tp,ids)
 
-# show 
+# show
 # cv2.imshow("HPatches example", vis/255)
 # cv2.waitKey(0)
 

--- a/python/utils/hpatch.py
+++ b/python/utils/hpatch.py
@@ -10,7 +10,7 @@ import time
 import scipy
 import copy
 
-# all types of patches 
+# all types of patches
 tps = ['ref','e1','e2','e3','e4','e5','h1','h2','h3','h4','h5',\
        't1','t2','t3','t4','t5']
 
@@ -22,7 +22,7 @@ def vis_patches(seq,tp,ids):
     vis_tmp = np.empty((35, 0))
     for t in tp:
         tp_patch = 255*np.ones((35,65))
-        cv2.putText(tp_patch,t,(5,25),cv2.FONT_HERSHEY_DUPLEX , 1,0,1)                       
+        cv2.putText(tp_patch,t,(5,25),cv2.FONT_HERSHEY_DUPLEX , 1,0,1)
         vis_tmp = np.hstack((vis_tmp,tp_patch))
     vis = np.vstack((vis,vis_tmp))
     # add the actual patches
@@ -43,8 +43,8 @@ def get_im(seq,t):#rename this as a general method
 
 def load_splits(f_splits):
     """Loads the json encoded splits"""
-    with open(f_splits) as f:    
-        splits = json.load(f)   
+    with open(f_splits) as f:
+        splits = json.load(f)
     return splits
 
 def load_descrs(path,dist='L2',descr_type='',sep=','):
@@ -62,7 +62,7 @@ def load_descrs(path,dist='L2',descr_type='',sep=','):
     seqs['distance'] = dist
     seqs['dim'] = seqs_l[0].dim
     print('>> Descriptor files loaded.')
-    return seqs	
+    return seqs
 
 
 ###############
@@ -75,7 +75,7 @@ def compute_pcapl(descr,split):
     for seq in split['train']:
         X = np.vstack((X,get_im(descr[seq],'ref')))
     X -= np.mean(X, axis=0)
-    
+
     Xcov = np.dot(X.T,X)
     Xcov = (Xcov + Xcov.T) / (2 * X.shape[0]);
     d, V = np.linalg.eigh(Xcov)
@@ -105,7 +105,7 @@ class hpatch_descr:
     itr = tps
     def __init__(self,base,descr_type='',sep=','):
         self.base = base
-        self.name = base.split("/")[-1]
+        self.name = base.split(os.path.sep)[-1]
 
         for t in self.itr:
             descr_path = os.path.join(base, t+'.csv')
@@ -124,7 +124,7 @@ class hpatch_sequence:
     """Class for loading an HPatches sequence from a sequence folder"""
     itr = tps
     def __init__(self,base):
-        name = base.split('/')
+        name = base.split(os.path.sep)
         self.name = name[-1]
         self.base = base
         for t in self.itr:
@@ -132,4 +132,3 @@ class hpatch_sequence:
             im = cv2.imread(im_path,0)
             self.N = im.shape[0]/65
             setattr(self, t, np.split(im, self.N))
-            

--- a/python/utils/results.py
+++ b/python/utils/results.py
@@ -1,6 +1,7 @@
 from utils.misc import *
 import dill
 import pprint
+from os import path
 from tabulate import tabulate as tb
 import numpy as np
 
@@ -8,7 +9,7 @@ ft = {'e':'Easy','h':'Hard','t':'Tough'}
 
 def results_verification(desc,splt):
     v = {'balanced':'auc','imbalanced':'ap'}
-    res = dill.load( open( "results/"+desc+"_verification_"+splt['name']+".p", "rb"))
+    res = dill.load(open(path.join("results", desc+"_verification_"+splt['name']+".p"), "rb"))
     for r in v:
         print("%s - %s variant (%s) " % (blue(desc.upper()),r.capitalize(),v[r]))
         heads = ["Noise","Inter","Intra"]
@@ -19,7 +20,7 @@ def results_verification(desc,splt):
 
 
 def results_matching(desc,splt):
-    res = dill.load( open( "results/"+desc+"_matching_"+splt['name']+".p", "rb"))
+    res = dill.load(open(path.join("results", desc+"_matching_"+splt['name']+".p"), "rb"))
     mAP = {'e':0,'h':0,'t':0}
     k_mAP = 0
     heads = [ft['e'],ft['h'],ft['t'],'mean']
@@ -38,7 +39,7 @@ def results_matching(desc,splt):
 
 
 def results_retrieval(desc,splt):
-    res = dill.load( open( "results/"+desc+"_retrieval_"+splt['name']+".p", "rb"))
+    res = dill.load(open(path.join("results", desc+"_retrieval_"+splt['name']+".p"), "rb"))
     print("%s - mAP 10K queries " % (blue(desc.upper())))
     n_q= float(len(res.keys()))
     heads = ['']
@@ -65,6 +66,8 @@ def results_retrieval(desc,splt):
     results.append(['mean']+list(np.mean(res,axis=0)))
     print(tb(results,headers=heads))
 
-results_methods = {'verification': results_verification,\
-           'matching': results_matching,\
-           'retrieval': results_retrieval}
+results_methods = {
+    'verification': results_verification,
+    'matching': results_matching,
+    'retrieval': results_retrieval
+}

--- a/python/utils/results.py
+++ b/python/utils/results.py
@@ -1,7 +1,7 @@
 from utils.misc import *
 import dill
 import pprint
-from os import path
+import os.path
 from tabulate import tabulate as tb
 import numpy as np
 
@@ -9,7 +9,7 @@ ft = {'e':'Easy','h':'Hard','t':'Tough'}
 
 def results_verification(desc,splt):
     v = {'balanced':'auc','imbalanced':'ap'}
-    res = dill.load(open(path.join("results", desc+"_verification_"+splt['name']+".p"), "rb"))
+    res = dill.load(open(os.path.join("results", desc+"_verification_"+splt['name']+".p"), "rb"))
     for r in v:
         print("%s - %s variant (%s) " % (blue(desc.upper()),r.capitalize(),v[r]))
         heads = ["Noise","Inter","Intra"]
@@ -20,7 +20,7 @@ def results_verification(desc,splt):
 
 
 def results_matching(desc,splt):
-    res = dill.load(open(path.join("results", desc+"_matching_"+splt['name']+".p"), "rb"))
+    res = dill.load(open(os.path.join("results", desc+"_matching_"+splt['name']+".p"), "rb"))
     mAP = {'e':0,'h':0,'t':0}
     k_mAP = 0
     heads = [ft['e'],ft['h'],ft['t'],'mean']
@@ -39,7 +39,7 @@ def results_matching(desc,splt):
 
 
 def results_retrieval(desc,splt):
-    res = dill.load(open(path.join("results", desc+"_retrieval_"+splt['name']+".p"), "rb"))
+    res = dill.load(open(os.path.join("results", desc+"_retrieval_"+splt['name']+".p"), "rb"))
     print("%s - mAP 10K queries " % (blue(desc.upper())))
     n_q= float(len(res.keys()))
     heads = ['']


### PR DESCRIPTION
Greetings from Scape, @vbalnt! Very neat benchmarking tools.

Here are some minor fixes of the Python code:
- Use `os.path.join` throughout to ensure valid file paths also on Windows.
- Set paths to "tasks" and "data" folders based on `__file__` path of `.py` module.
- Add `--results-dir` option also to `hpatches_eval` and use same default for both `hpatches_eval` and `hpatches_results` scripts.